### PR TITLE
Add 'add column to table' and 'drop column from table' APIs

### DIFF
--- a/baastronaut-be/src/app.module.ts
+++ b/baastronaut-be/src/app.module.ts
@@ -14,6 +14,7 @@ import { BearerAuthGuard } from './modules/auth/bearer-auth.guard';
 import { ApiTokensModule } from './modules/api-tokens/api-tokens.module';
 import { UsersModule } from './modules/users/users.module';
 import { WorkspacesModule } from './modules/workspaces/workspaces.module';
+import { ColumnsModule } from './modules/columns/columns.module';
 
 @Module({
   imports: [
@@ -50,6 +51,7 @@ import { WorkspacesModule } from './modules/workspaces/workspaces.module';
     }),
     ProjectsModule,
     TablesModule,
+    ColumnsModule,
     UserDataModule,
     UserApisModule,
     UserApiDocsModule,

--- a/baastronaut-be/src/modules/columns/column-helpers.ts
+++ b/baastronaut-be/src/modules/columns/column-helpers.ts
@@ -1,0 +1,41 @@
+import { SupportedPostgresColType } from '../user-data-db/user-data-db-service';
+import { ColumnType } from './column.entity';
+
+export function mapColumnTypeToPostgresType(
+  columnType: ColumnType,
+): SupportedPostgresColType {
+  if (columnType === ColumnType.INTEGER) {
+    return SupportedPostgresColType.INTEGER;
+  } else if (columnType === ColumnType.FLOAT) {
+    return SupportedPostgresColType.FLOAT;
+  } else if (columnType === ColumnType.TEXT) {
+    return SupportedPostgresColType.TEXT;
+  } else if (columnType === ColumnType.BOOLEAN) {
+    return SupportedPostgresColType.BOOLEAN;
+  } else if (columnType === ColumnType.DATETIME) {
+    return SupportedPostgresColType.TIMESTAMPTZ;
+  }
+
+  throw new Error(`Type ${columnType} is not handled.`);
+}
+
+export function mapPostgresTypeToColumnType(
+  postgresType: SupportedPostgresColType,
+): ColumnType {
+  if (
+    postgresType === SupportedPostgresColType.SERIAL ||
+    postgresType === SupportedPostgresColType.INTEGER
+  ) {
+    return ColumnType.INTEGER;
+  } else if (postgresType === SupportedPostgresColType.FLOAT) {
+    return ColumnType.FLOAT;
+  } else if (postgresType === SupportedPostgresColType.TEXT) {
+    return ColumnType.TEXT;
+  } else if (postgresType === SupportedPostgresColType.BOOLEAN) {
+    return ColumnType.BOOLEAN;
+  } else if (postgresType === SupportedPostgresColType.TIMESTAMPTZ) {
+    return ColumnType.DATETIME;
+  }
+
+  throw new Error(`Type ${postgresType} is not handled.`);
+}

--- a/baastronaut-be/src/modules/columns/column.entity.ts
+++ b/baastronaut-be/src/modules/columns/column.entity.ts
@@ -7,7 +7,7 @@ import {
   PrimaryGeneratedColumn,
   UpdateDateColumn,
 } from 'typeorm';
-import { Table } from './table.entity';
+import { Table } from '../tables/table.entity';
 
 export enum ColumnType {
   INTEGER = 'INTEGER',

--- a/baastronaut-be/src/modules/columns/columns.controller.ts
+++ b/baastronaut-be/src/modules/columns/columns.controller.ts
@@ -1,0 +1,50 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Param,
+  ParseIntPipe,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
+import { HasAdminRightsGuard } from '../workspaces/workspace-auth.guard';
+import { ColumnsService } from './columns.service';
+import { ColumnResp, CreateColumnReq } from './types';
+
+@Controller(
+  'workspaces/:workspaceId/projects/:projectId/tables/:tableId/columns',
+)
+export class ColumnsController {
+  constructor(private columnsService: ColumnsService) {}
+
+  @UseGuards(HasAdminRightsGuard)
+  @Post()
+  async addTableColumn(
+    @Param('projectId', ParseIntPipe) projectId: number,
+    @Param('tableId', ParseIntPipe) tableId: number,
+    @Body() createColumnReq: CreateColumnReq,
+  ): Promise<ColumnResp> {
+    return await this.columnsService.addTableColumn(
+      projectId,
+      tableId,
+      createColumnReq,
+    );
+  }
+
+  /**
+   * This will delete the column and all the data in the column and the action
+   * is **irreversible**.
+   */
+  @UseGuards(HasAdminRightsGuard)
+  @Delete(':columnId')
+  async dropTableColumn(
+    @Param('projectId', ParseIntPipe) projectId: number,
+    @Param('tableId', ParseIntPipe) tableId: number,
+    @Param('columnId', ParseIntPipe) columnId: number,
+  ) {
+    await this.columnsService.dropTableColumn(projectId, tableId, columnId);
+    return {
+      success: true,
+    };
+  }
+}

--- a/baastronaut-be/src/modules/columns/columns.controller.ts
+++ b/baastronaut-be/src/modules/columns/columns.controller.ts
@@ -9,7 +9,7 @@ import {
 } from '@nestjs/common';
 import { HasAdminRightsGuard } from '../workspaces/workspace-auth.guard';
 import { ColumnsService } from './columns.service';
-import { ColumnResp, CreateColumnReq } from './types';
+import { AddColumnReq, ColumnResp } from './types';
 
 @Controller(
   'workspaces/:workspaceId/projects/:projectId/tables/:tableId/columns',
@@ -22,12 +22,12 @@ export class ColumnsController {
   async addTableColumn(
     @Param('projectId', ParseIntPipe) projectId: number,
     @Param('tableId', ParseIntPipe) tableId: number,
-    @Body() createColumnReq: CreateColumnReq,
+    @Body() addColumnReq: AddColumnReq,
   ): Promise<ColumnResp> {
     return await this.columnsService.addTableColumn(
       projectId,
       tableId,
-      createColumnReq,
+      addColumnReq,
     );
   }
 

--- a/baastronaut-be/src/modules/columns/columns.module.ts
+++ b/baastronaut-be/src/modules/columns/columns.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { TableColumn } from './column.entity';
+import { Table } from '../tables/table.entity';
+import { UserDataDBModule } from '../user-data-db/user-data-db.module';
+import { ColumnsController } from './columns.controller';
+import { ColumnsService } from './columns.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Table, TableColumn]), UserDataDBModule],
+  controllers: [ColumnsController],
+  providers: [ColumnsService],
+})
+export class ColumnsModule {}

--- a/baastronaut-be/src/modules/columns/columns.service.ts
+++ b/baastronaut-be/src/modules/columns/columns.service.ts
@@ -3,7 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { TableColumn } from './column.entity';
 import { UserDataDBService } from '../user-data-db/user-data-db-service';
-import { ColumnResp, CreateColumnReq } from './types';
+import { AddColumnReq, ColumnResp } from './types';
 import { Table } from '../tables/table.entity';
 import { nameToPostgresIdentifier } from '../../utils/names-identifiers-parser';
 import { mapColumnTypeToPostgresType } from './column-helpers';
@@ -21,7 +21,7 @@ export class ColumnsService {
   async addTableColumn(
     projectId: number,
     tableId: number,
-    createColumnReq: CreateColumnReq,
+    addColumnReq: AddColumnReq,
   ): Promise<ColumnResp> {
     const tableEntity = await this.tablesRepository.findOne({
       where: {
@@ -36,7 +36,7 @@ export class ColumnsService {
       throw new NotFoundException('Table not found.');
     }
 
-    const pgColumnIdentifier = nameToPostgresIdentifier(createColumnReq.name);
+    const pgColumnIdentifier = nameToPostgresIdentifier(addColumnReq.name);
 
     await this.userDataDBService.addTableColumn({
       table: {
@@ -45,8 +45,8 @@ export class ColumnsService {
       },
       newColumn: {
         identifier: pgColumnIdentifier,
-        columnType: mapColumnTypeToPostgresType(createColumnReq.columnType),
-        required: createColumnReq.required,
+        columnType: mapColumnTypeToPostgresType(addColumnReq.columnType),
+        required: false,
         primary: false,
         default: undefined,
       },
@@ -54,11 +54,11 @@ export class ColumnsService {
 
     const newColumnEntity = await this.columnsRepository.save({
       tableId: tableEntity.id!,
-      name: createColumnReq.name,
-      description: createColumnReq.description,
-      columnType: createColumnReq.columnType,
+      name: addColumnReq.name,
+      description: addColumnReq.description,
+      columnType: addColumnReq.columnType,
       pgColumnIdentifier,
-      required: createColumnReq.required,
+      required: false,
       createdAt: new Date(),
       updatedAt: new Date(),
     });

--- a/baastronaut-be/src/modules/columns/columns.service.ts
+++ b/baastronaut-be/src/modules/columns/columns.service.ts
@@ -1,0 +1,110 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { TableColumn } from './column.entity';
+import { UserDataDBService } from '../user-data-db/user-data-db-service';
+import { ColumnResp, CreateColumnReq } from './types';
+import { Table } from '../tables/table.entity';
+import { nameToPostgresIdentifier } from '../../utils/names-identifiers-parser';
+import { mapColumnTypeToPostgresType } from './column-helpers';
+
+@Injectable()
+export class ColumnsService {
+  constructor(
+    @InjectRepository(TableColumn)
+    private columnsRepository: Repository<TableColumn>,
+    @InjectRepository(Table)
+    private tablesRepository: Repository<Table>,
+    private userDataDBService: UserDataDBService,
+  ) {}
+
+  async addTableColumn(
+    projectId: number,
+    tableId: number,
+    createColumnReq: CreateColumnReq,
+  ): Promise<ColumnResp> {
+    const tableEntity = await this.tablesRepository.findOne({
+      where: {
+        projectId,
+        id: tableId,
+      },
+      relations: {
+        project: true,
+      },
+    });
+    if (!tableEntity) {
+      throw new NotFoundException('Table not found.');
+    }
+
+    const pgColumnIdentifier = nameToPostgresIdentifier(createColumnReq.name);
+
+    await this.userDataDBService.addTableColumn({
+      table: {
+        schema: tableEntity.project!.pgSchemaIdentifier,
+        identifier: tableEntity.pgTableIdentifier,
+      },
+      newColumn: {
+        identifier: pgColumnIdentifier,
+        columnType: mapColumnTypeToPostgresType(createColumnReq.columnType),
+        required: createColumnReq.required,
+        primary: false,
+        default: undefined,
+      },
+    });
+
+    const newColumnEntity = await this.columnsRepository.save({
+      tableId: tableEntity.id!,
+      name: createColumnReq.name,
+      description: createColumnReq.description,
+      columnType: createColumnReq.columnType,
+      pgColumnIdentifier,
+      required: createColumnReq.required,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    return {
+      id: newColumnEntity.id!,
+      createdAt: newColumnEntity.createdAt!.toISOString(),
+      updatedAt: newColumnEntity.updatedAt!.toISOString(),
+      tableId: tableEntity.id!,
+      description: newColumnEntity.description,
+      pgColumnIdentifier: newColumnEntity.pgColumnIdentifier,
+      name: newColumnEntity.name,
+      columnType: newColumnEntity.columnType,
+      required: newColumnEntity.required,
+    };
+  }
+
+  /**
+   * Drops a column from a table. This will delete the column and all the data in it.
+   * It is irreversible.
+   */
+  async dropTableColumn(projectId: number, tableId: number, columnId: number) {
+    const columnEntity = await this.columnsRepository.findOne({
+      where: {
+        tableId,
+        id: columnId,
+      },
+      relations: {
+        table: {
+          project: true,
+        },
+      },
+    });
+
+    if (!columnEntity || columnEntity.table!.projectId !== projectId) {
+      throw new NotFoundException('Column not found.');
+    }
+
+    await this.userDataDBService.dropTableColumn({
+      table: {
+        schema: columnEntity.table!.project!.pgSchemaIdentifier,
+        identifier: columnEntity.table!.pgTableIdentifier,
+      },
+      columnIdentifier: columnEntity.pgColumnIdentifier,
+    });
+
+    await this.columnsRepository.delete(columnEntity.id!);
+  }
+}

--- a/baastronaut-be/src/modules/columns/types.ts
+++ b/baastronaut-be/src/modules/columns/types.ts
@@ -3,9 +3,9 @@ import { IsValidName } from '../../utils/validators';
 import { ColumnType } from './column.entity';
 
 /**
- * Not supporting default values yet just to simplify things.
+ * For adding columns to existing table.
  */
-export class CreateColumnReq {
+export class AddColumnReq {
   @Length(1, 63)
   @IsValidName()
   name: string;
@@ -15,6 +15,13 @@ export class CreateColumnReq {
   @IsEnum(ColumnType)
   columnType: ColumnType;
 
+  // TODO: required and default (if required is true)
+}
+
+/**
+ * Not supporting default values yet just to simplify things.
+ */
+export class CreateColumnReq extends AddColumnReq {
   @IsBoolean()
   required: boolean;
 }

--- a/baastronaut-be/src/modules/columns/types.ts
+++ b/baastronaut-be/src/modules/columns/types.ts
@@ -1,0 +1,39 @@
+import { IsBoolean, IsEnum, Length } from 'class-validator';
+import { IsValidName } from '../../utils/validators';
+import { ColumnType } from './column.entity';
+
+/**
+ * Not supporting default values yet just to simplify things.
+ */
+export class CreateColumnReq {
+  @Length(1, 63)
+  @IsValidName()
+  name: string;
+
+  description: string | null;
+
+  @IsEnum(ColumnType)
+  columnType: ColumnType;
+
+  @IsBoolean()
+  required: boolean;
+}
+
+type BaseColumnDetails = {
+  pgColumnIdentifier: string;
+  name: string;
+  columnType: ColumnType;
+  required: boolean;
+};
+
+export type GeneratedColumnResp = BaseColumnDetails & {
+  primary: boolean;
+};
+
+export type ColumnResp = BaseColumnDetails & {
+  id: number;
+  createdAt: string;
+  updatedAt: string;
+  tableId: number;
+  description: string | null;
+};

--- a/baastronaut-be/src/modules/tables/table.entity.ts
+++ b/baastronaut-be/src/modules/tables/table.entity.ts
@@ -10,7 +10,7 @@ import {
 } from 'typeorm';
 import { Project } from '../projects/project.entity';
 import { User } from '../users/user.entity';
-import { TableColumn } from './column.entity';
+import { TableColumn } from '../columns/column.entity';
 
 @Entity({
   name: 'tables',

--- a/baastronaut-be/src/modules/tables/tables.module.ts
+++ b/baastronaut-be/src/modules/tables/tables.module.ts
@@ -3,7 +3,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { EncryptionModule } from '../encryption/encryption.module';
 import { ProjectsModule } from '../projects/projects.module';
 import { UserDataDBModule } from '../user-data-db/user-data-db.module';
-import { TableColumn } from './column.entity';
+import { TableColumn } from '../columns/column.entity';
 import { FtsGroup, FtsGroupColumn } from './fts-group.entity';
 import { Table } from './table.entity';
 import { TablesController } from './tables.controller';

--- a/baastronaut-be/src/modules/tables/tables.service.ts
+++ b/baastronaut-be/src/modules/tables/tables.service.ts
@@ -20,51 +20,15 @@ import {
   SupportedPostgresColType,
   UserDataDBService,
 } from '../user-data-db/user-data-db-service';
-import { ColumnType } from './column.entity';
 import { DEFAULT_GENERATED_COLUMN_NAMES } from './constants';
 import { FtsGroup } from './fts-group.entity';
 import { Table } from './table.entity';
 import { TABLES_PAGINATION_CONFIG } from './tables-pagination.config';
 import { CreateFtsGroupReq, CreateTableReq, TableResp } from './types';
-
-function mapColumnTypeToPostgresType(
-  columnType: ColumnType,
-): SupportedPostgresColType {
-  if (columnType === ColumnType.INTEGER) {
-    return SupportedPostgresColType.INTEGER;
-  } else if (columnType === ColumnType.FLOAT) {
-    return SupportedPostgresColType.FLOAT;
-  } else if (columnType === ColumnType.TEXT) {
-    return SupportedPostgresColType.TEXT;
-  } else if (columnType === ColumnType.BOOLEAN) {
-    return SupportedPostgresColType.BOOLEAN;
-  } else if (columnType === ColumnType.DATETIME) {
-    return SupportedPostgresColType.TIMESTAMPTZ;
-  }
-
-  throw new Error(`Type ${columnType} is not handled.`);
-}
-
-function mapPostgresTypeToColumnType(
-  postgresType: SupportedPostgresColType,
-): ColumnType {
-  if (
-    postgresType === SupportedPostgresColType.SERIAL ||
-    postgresType === SupportedPostgresColType.INTEGER
-  ) {
-    return ColumnType.INTEGER;
-  } else if (postgresType === SupportedPostgresColType.FLOAT) {
-    return ColumnType.FLOAT;
-  } else if (postgresType === SupportedPostgresColType.TEXT) {
-    return ColumnType.TEXT;
-  } else if (postgresType === SupportedPostgresColType.BOOLEAN) {
-    return ColumnType.BOOLEAN;
-  } else if (postgresType === SupportedPostgresColType.TIMESTAMPTZ) {
-    return ColumnType.DATETIME;
-  }
-
-  throw new Error(`Type ${postgresType} is not handled.`);
-}
+import {
+  mapColumnTypeToPostgresType,
+  mapPostgresTypeToColumnType,
+} from '../columns/column-helpers';
 
 type DefaultGeneratedColumnDetails = NewColumnDetails & {
   name: string;

--- a/baastronaut-be/src/modules/tables/types.ts
+++ b/baastronaut-be/src/modules/tables/types.ts
@@ -1,7 +1,6 @@
 import { Type } from 'class-transformer';
 import {
   IsArray,
-  IsBoolean,
   IsEnum,
   IsInt,
   IsOptional,
@@ -10,24 +9,11 @@ import {
   ValidateNested,
 } from 'class-validator';
 import { IsNotBlank, IsValidName } from '../../utils/validators';
-import { ColumnType } from './column.entity';
-
-/**
- * Not supporting default values yet just to simplify things.
- */
-export class ColumnReq {
-  @Length(1, 63)
-  @IsValidName()
-  name: string;
-
-  description: string | null;
-
-  @IsEnum(ColumnType)
-  columnType: ColumnType;
-
-  @IsBoolean()
-  required: boolean;
-}
+import {
+  ColumnResp,
+  CreateColumnReq,
+  GeneratedColumnResp,
+} from '../columns/types';
 
 export class CreateTableReq {
   @Length(1, 63)
@@ -38,28 +24,9 @@ export class CreateTableReq {
 
   @ValidateNested()
   @IsArray()
-  @Type(() => ColumnReq)
-  columns: ColumnReq[];
+  @Type(() => CreateColumnReq)
+  columns: CreateColumnReq[];
 }
-
-type BaseColumnDetails = {
-  pgColumnIdentifier: string;
-  name: string;
-  columnType: ColumnType;
-  required: boolean;
-};
-
-export type GeneratedColumnResp = BaseColumnDetails & {
-  primary: boolean;
-};
-
-export type ColumnResp = BaseColumnDetails & {
-  id: number;
-  createdAt: string;
-  updatedAt: string;
-  tableId: number;
-  description: string | null;
-};
 
 export type TableResp = {
   id: number;


### PR DESCRIPTION
This PR adds 2 APIs to modify a table structure:
1. Add column to table.
2. Drop column from table.

**Add column to table**
There's no way to set the new column as `required` for now because that would require a default value for existing rows. We can either prefill with zero values or ask user to supply one. This is to be discussed and added in the future.

**Drop column from table**
Nothing to note here. We don't support foreign-keys now, so this is straightforward.